### PR TITLE
Restyle monthly calendar grid with flat design badges

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,6 +69,7 @@ let fileHandle = null;
 $('#file').onchange = (e)=>{ fileHandle = e.target.files?.[0] || null; $('#status').textContent = fileHandle? `已选择：${fileHandle.name}`:'未加载文件'; };
 const worker = new Worker('./parser.worker.js?v=7', {type:'module'});
 let currentSummary = null;
+let lastSummary = null;
 
 $('#runPrecheck').onclick = ()=>{
   if(!fileHandle){ $('#status').textContent = '请先选择 JSON 文件'; return; }
@@ -93,6 +94,7 @@ worker.onmessage = (e)=>{
   } else if(type==='done'){
     const {summary = null} = data;
     currentSummary = summary;
+    lastSummary = summary;
     renderSummaryBasics(summary);
     const hotSlot = summarizeHotSlot(summary?.timeOfDay);
     $('#hotSlot').textContent = hotSlot || '—';
@@ -104,6 +106,7 @@ worker.onmessage = (e)=>{
       statusText += '（性能保护：基于抽样）';
     }
     $('#status').textContent = statusText;
+    renderMonthGrid(lastSummary);
   } else if(type==='error'){
     $('#status').textContent = data.message || '未知错误';
   }
@@ -248,4 +251,76 @@ function formatRun(run){
   const start = run.start.replaceAll('-', '/');
   const end = run.end.replaceAll('-', '/');
   return `${start}–${end} · ${run.length}天`;
+}
+
+function renderMonthGrid(summary){
+  const container = $('#monthGrid');
+  if(!container){ return; }
+  if(!summary){
+    container.innerHTML = '';
+    return;
+  }
+
+  const monthDailyChars = summary?.monthDailyChars || {};
+  const weekdayLabels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+  const now = new Date();
+  const currentMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const months = [];
+  for(let i = 0; i < 3; i += 1){
+    months.push(new Date(currentMonthStart.getFullYear(), currentMonthStart.getMonth() - i, 1));
+  }
+
+  const parts = [];
+  months.forEach((monthDate, index) => {
+    const year = monthDate.getFullYear();
+    const monthIndex = monthDate.getMonth();
+    const monthKey = `${year}-${String(monthIndex + 1).padStart(2, '0')}`;
+    const firstDay = new Date(year, monthIndex, 1);
+    const totalDays = new Date(year, monthIndex + 1, 0).getDate();
+    const offset = (firstDay.getDay() + 6) % 7;
+
+    parts.push(`<div class="month-title">${monthKey}</div>`);
+    parts.push(weekdayLabels.map(label => `<div class="dow">${label}</div>`).join(''));
+
+    for(let i = 0; i < offset; i += 1){
+      parts.push('<div class="day empty"></div>');
+    }
+
+    for(let day = 1; day <= totalDays; day += 1){
+      const dayKey = `${monthKey}-${String(day).padStart(2, '0')}`;
+      let safeCount = Number(monthDailyChars?.[dayKey]);
+      if(!Number.isFinite(safeCount)){
+        safeCount = 0;
+      }else{
+        safeCount = Math.trunc(safeCount);
+      }
+
+      const classes = ['day'];
+      if(safeCount === 0){
+        classes.push('muted');
+      }
+
+      let countMarkup = '';
+      if(safeCount > 0){
+        countMarkup = `<span class="pill mono">${safeCount}</span>`;
+      }else{
+        countMarkup = `<span class="count mono">0</span>`;
+      }
+
+      parts.push(`
+        <div class="${classes.join(' ')}">
+          <span class="date mono">${day}</span>
+          ${countMarkup}
+        </div>
+      `.trim());
+    }
+
+    const totalCells = offset + totalDays;
+    const trailing = (7 - (totalCells % 7)) % 7;
+    for(let i = 0; i < trailing; i += 1){
+      parts.push('<div class="day empty"></div>');
+    }
+  });
+
+  container.innerHTML = parts.join('');
 }

--- a/index.html
+++ b/index.html
@@ -37,6 +37,69 @@ button.ghost{ background:var(--surface); color:var(--text) }
 .theme[aria-pressed="true"]{ outline:2px solid var(--accent) }
 .badge{ display:inline-block; padding:2px 8px; border-radius:999px; background:var(--accent); color:var(--accent-contrast); font-weight:700 }
 
+#monthGrid{
+  display:grid;
+  grid-template-columns:repeat(7,1fr);
+  gap:6px;
+  margin-top:12px;
+}
+#monthGrid .month-title{
+  grid-column:span 7;
+  font-weight:700;
+  font-size:16px;
+  margin:12px 0 0;
+}
+#monthGrid .month-title:first-child{ margin-top:0 }
+#monthGrid .dow{
+  font-weight:650;
+  text-align:center;
+  padding:6px 0 2px;
+  margin-top:6px;
+}
+#monthGrid .day{
+  min-height:38px;
+  padding:6px 8px;
+  border-radius:var(--radius);
+  background:var(--surface);
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  justify-content:flex-start;
+  font-variant-numeric:tabular-nums;
+  position:relative;
+}
+#monthGrid .day .date{
+  font-weight:600;
+}
+#monthGrid .day .count,
+#monthGrid .day .pill{
+  margin-top:auto;
+  align-self:flex-end;
+}
+#monthGrid .day .count{
+  font-size:12px;
+  opacity:.7;
+}
+#monthGrid .day .count::before{ content:'· ' }
+#monthGrid .day .pill{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:2px 8px;
+  border-radius:999px;
+  background:var(--accent);
+  color:var(--accent-contrast);
+  font-weight:700;
+  font-size:12px;
+}
+#monthGrid .day.muted{ opacity:.5 }
+#monthGrid .day.empty{ visibility:hidden }
+
+@media (max-width:640px){
+  #monthGrid{ gap:4px }
+  #monthGrid .day{ min-height:36px; padding:5px 6px }
+}
+
 /* —— 主题（语义色：bg 最浅 / card 次浅 / surface 控件底 / accent 强调） —— */
 body[data-theme="Echoes"]{
   --bg:#aac1b0; --card:#f2eee1; --surface:#a7acb7; --accent:#617ba2; --accent-contrast:#fff; --text:#102010;


### PR DESCRIPTION
## Summary
- restructure the monthly summary markup into a flat 7-column grid with weekday headers and per-day cells
- add pill badges for non-zero days and muted styling for zero-count placeholders while preserving blank offsets
- apply responsive, theme-aware calendar styling in CSS to achieve the requested flat design

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4e02e11388330910865adc164e183