### PR TITLE
Adjust month grid CSS layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,68 +39,27 @@ button.ghost{ background:var(--surface); color:var(--text) }
 .theme[aria-pressed="true"]{ outline:2px solid var(--accent) }
 .badge{ display:inline-block; padding:2px 8px; border-radius:999px; background:var(--accent); color:var(--accent-contrast); font-weight:700 }
 
-#monthGrid{
-  display:grid;
-  grid-template-columns:repeat(7,1fr);
-  gap:6px;
-  margin-top:12px;
-}
-#monthGrid .month-title{
-  grid-column:span 7;
-  font-weight:700;
-  font-size:16px;
-  margin:12px 0 0;
-}
-#monthGrid .month-title:first-child{ margin-top:0 }
-#monthGrid .dow{
-  font-weight:650;
-  text-align:center;
-  padding:6px 0 2px;
-  margin-top:6px;
-}
-#monthGrid .day{
-  min-height:38px;
-  padding:6px 8px;
+#monthGrid{ display:block; margin-top:12px; }
+.month{ margin:12px 0 16px; }
+.month-title{ font-weight:800; font-size:16px; margin:4px 0 8px; }
+.dow{ font-weight:700; text-align:center; margin:6px 0; }
+.month-grid{ display:grid; grid-template-columns:repeat(7,1fr); gap:8px; }
+.day{
+  min-height:60px;
+  padding:8px;
   border-radius:var(--radius);
   background:var(--surface);
   display:flex;
   flex-direction:column;
-  gap:6px;
-  justify-content:flex-start;
+  justify-content:space-between;
+  align-items:flex-start;
   font-variant-numeric:tabular-nums;
-  position:relative;
 }
-#monthGrid .day .date{
-  font-weight:600;
-}
-#monthGrid .day .count,
-#monthGrid .day .pill{
-  margin-top:auto;
-  align-self:flex-end;
-}
-#monthGrid .day .count{
-  font-size:12px;
-  opacity:.7;
-}
-#monthGrid .day .count::before{ content:'· ' }
-#monthGrid .day .pill{
-  display:inline-flex;
-  align-items:center;
-  justify-content:center;
-  padding:2px 8px;
-  border-radius:999px;
-  background:var(--accent);
-  color:var(--accent-contrast);
-  font-weight:700;
-  font-size:12px;
-}
-#monthGrid .day.muted{ opacity:.5 }
-#monthGrid .day.empty{ visibility:hidden }
-
-@media (max-width:640px){
-  #monthGrid{ gap:4px }
-  #monthGrid .day{ min-height:36px; padding:5px 6px }
-}
+.day.zero{ opacity:.45; }
+.day.empty{ visibility:hidden; }
+.day .d{ font-weight:700; }
+.day .cnt{ font-size:12px; opacity:.9; }
+@media (max-width:640px){ .month-grid{ gap:6px } .day{ min-height:54px; padding:6px } }
 
 /* —— 主题（语义色：bg 最浅 / card 次浅 / surface 控件底 / accent 强调） —— */
 body[data-theme="Echoes"]{


### PR DESCRIPTION
## Summary
- switch the month container to a block layout and add dedicated month/day styles
- introduce per-month grids with consistent spacing and responsive tweaks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4f1daeac88330a85536620b529de6