### PR TITLE
Adjust month grid layout and enable tile renderer

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,7 +69,6 @@ let fileHandle = null;
 $('#file').onchange = (e)=>{ fileHandle = e.target.files?.[0] || null; $('#status').textContent = fileHandle? `已选择：${fileHandle.name}`:'未加载文件'; };
 const worker = new Worker('./parser.worker.js?v=7', {type:'module'});
 let currentSummary = null;
-let lastSummary = null;
 
 $('#runPrecheck').onclick = ()=>{
   if(!fileHandle){ $('#status').textContent = '请先选择 JSON 文件'; return; }
@@ -94,7 +93,6 @@ worker.onmessage = (e)=>{
   } else if(type==='done'){
     const {summary = null} = data;
     currentSummary = summary;
-    lastSummary = summary;
     renderSummaryBasics(summary);
     const hotSlot = summarizeHotSlot(summary?.timeOfDay);
     $('#hotSlot').textContent = hotSlot || '—';
@@ -106,7 +104,7 @@ worker.onmessage = (e)=>{
       statusText += '（性能保护：基于抽样）';
     }
     $('#status').textContent = statusText;
-    renderMonthGrid(lastSummary);
+    renderMonthlyTiles(summary);
   } else if(type==='error'){
     $('#status').textContent = data.message || '未知错误';
   }
@@ -253,15 +251,18 @@ function formatRun(run){
   return `${start}–${end} · ${run.length}天`;
 }
 
-function renderMonthGrid(summary){
+function renderMonthlyTiles(summary){
   const container = $('#monthGrid');
   if(!container){ return; }
+
+  const monthDailyChars = summary?.monthDailyChars || {};
+  console.log('[monthly] tiles render', Object.keys(monthDailyChars).length);
+
   if(!summary){
     container.innerHTML = '';
     return;
   }
 
-  const monthDailyChars = summary?.monthDailyChars || {};
   const weekdayLabels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
   const now = new Date();
   const currentMonthStart = new Date(now.getFullYear(), now.getMonth(), 1);
@@ -270,7 +271,9 @@ function renderMonthGrid(summary){
     months.push(new Date(currentMonthStart.getFullYear(), currentMonthStart.getMonth() - i, 1));
   }
 
-  const sections = months.map(monthDate => {
+  const fragment = document.createDocumentFragment();
+
+  months.forEach(monthDate => {
     const year = monthDate.getFullYear();
     const monthIndex = monthDate.getMonth();
     const monthKey = `${year}-${String(monthIndex + 1).padStart(2, '0')}`;
@@ -278,10 +281,32 @@ function renderMonthGrid(summary){
     const totalDays = new Date(year, monthIndex + 1, 0).getDate();
     const offset = (firstDay.getDay() + 6) % 7;
 
-    const cells = [];
+    const monthSection = document.createElement('section');
+    monthSection.className = 'month';
+
+    const titleEl = document.createElement('div');
+    titleEl.className = 'month-title';
+    titleEl.textContent = monthKey;
+    monthSection.appendChild(titleEl);
+
+    const dowEl = document.createElement('div');
+    dowEl.className = 'dow month-grid';
+    weekdayLabels.forEach(label => {
+      const cell = document.createElement('div');
+      cell.textContent = label;
+      dowEl.appendChild(cell);
+    });
+    monthSection.appendChild(dowEl);
+
+    const monthGrid = document.createElement('div');
+    monthGrid.className = 'month-grid';
+
     for(let i = 0; i < offset; i += 1){
-      cells.push('');
+      const emptyCell = document.createElement('div');
+      emptyCell.className = 'day empty';
+      monthGrid.appendChild(emptyCell);
     }
+
     for(let day = 1; day <= totalDays; day += 1){
       const dayKey = `${monthKey}-${String(day).padStart(2, '0')}`;
       let safeCount = Number(monthDailyChars?.[dayKey]);
@@ -290,33 +315,36 @@ function renderMonthGrid(summary){
       }else{
         safeCount = Math.trunc(safeCount);
       }
-      const label = `${day}: ${safeCount}`;
-      cells.push(label);
-    }
-    while(cells.length % 7 !== 0){
-      cells.push('');
+
+      const dayEl = document.createElement('div');
+      dayEl.className = 'day';
+      if(safeCount <= 0){
+        dayEl.classList.add('zero');
+      }
+
+      const dayNumber = document.createElement('div');
+      dayNumber.className = 'd';
+      dayNumber.textContent = String(day);
+      dayEl.appendChild(dayNumber);
+
+      const countEl = document.createElement('div');
+      countEl.className = 'cnt';
+      countEl.textContent = formatCount(safeCount);
+      dayEl.appendChild(countEl);
+
+      monthGrid.appendChild(dayEl);
     }
 
-    const headerRow = `<tr>${weekdayLabels.map(label => `<th>${label}</th>`).join('')}</tr>`;
-    const bodyRows = [];
-    for(let idx = 0; idx < cells.length; idx += 7){
-      const rowCells = cells
-        .slice(idx, idx + 7)
-        .map(cell => `<td>${cell || ''}</td>`)
-        .join('');
-      bodyRows.push(`<tr>${rowCells}</tr>`);
+    while(monthGrid.children.length % 7 !== 0){
+      const emptyCell = document.createElement('div');
+      emptyCell.className = 'day empty';
+      monthGrid.appendChild(emptyCell);
     }
 
-    return `
-      <section class="month-block">
-        <h3>${monthKey}</h3>
-        <table class="month-grid-table">
-          ${headerRow}
-          ${bodyRows.join('')}
-        </table>
-      </section>
-    `;
+    monthSection.appendChild(monthGrid);
+    fragment.appendChild(monthSection);
   });
 
-  container.innerHTML = sections.join('');
+  container.innerHTML = '';
+  container.appendChild(fragment);
 }

--- a/index.html
+++ b/index.html
@@ -39,68 +39,27 @@ button.ghost{ background:var(--surface); color:var(--text) }
 .theme[aria-pressed="true"]{ outline:2px solid var(--accent) }
 .badge{ display:inline-block; padding:2px 8px; border-radius:999px; background:var(--accent); color:var(--accent-contrast); font-weight:700 }
 
-#monthGrid{
-  display:grid;
-  grid-template-columns:repeat(7,1fr);
-  gap:6px;
-  margin-top:12px;
-}
-#monthGrid .month-title{
-  grid-column:span 7;
-  font-weight:700;
-  font-size:16px;
-  margin:12px 0 0;
-}
-#monthGrid .month-title:first-child{ margin-top:0 }
-#monthGrid .dow{
-  font-weight:650;
-  text-align:center;
-  padding:6px 0 2px;
-  margin-top:6px;
-}
-#monthGrid .day{
-  min-height:38px;
-  padding:6px 8px;
+#monthGrid{ display:block; margin-top:12px; }
+.month{ margin:12px 0 16px; }
+.month-title{ font-weight:800; font-size:16px; margin:4px 0 8px; }
+.dow{ font-weight:700; text-align:center; margin:6px 0; }
+.month-grid{ display:grid; grid-template-columns:repeat(7,1fr); gap:8px; }
+.day{
+  min-height:60px;
+  padding:8px;
   border-radius:var(--radius);
   background:var(--surface);
   display:flex;
   flex-direction:column;
-  gap:6px;
-  justify-content:flex-start;
+  justify-content:space-between;
+  align-items:flex-start;
   font-variant-numeric:tabular-nums;
-  position:relative;
 }
-#monthGrid .day .date{
-  font-weight:600;
-}
-#monthGrid .day .count,
-#monthGrid .day .pill{
-  margin-top:auto;
-  align-self:flex-end;
-}
-#monthGrid .day .count{
-  font-size:12px;
-  opacity:.7;
-}
-#monthGrid .day .count::before{ content:'· ' }
-#monthGrid .day .pill{
-  display:inline-flex;
-  align-items:center;
-  justify-content:center;
-  padding:2px 8px;
-  border-radius:999px;
-  background:var(--accent);
-  color:var(--accent-contrast);
-  font-weight:700;
-  font-size:12px;
-}
-#monthGrid .day.muted{ opacity:.5 }
-#monthGrid .day.empty{ visibility:hidden }
-
-@media (max-width:640px){
-  #monthGrid{ gap:4px }
-  #monthGrid .day{ min-height:36px; padding:5px 6px }
-}
+.day.zero{ opacity:.45; }
+.day.empty{ visibility:hidden; }
+.day .d{ font-weight:700; }
+.day .cnt{ font-size:12px; opacity:.9; }
+@media (max-width:640px){ .month-grid{ gap:6px } .day{ min-height:54px; padding:6px } }
 
 /* —— 主题（语义色：bg 最浅 / card 次浅 / surface 控件底 / accent 强调） —— */
 body[data-theme="Echoes"]{


### PR DESCRIPTION
## Summary
- switch the month container to a block layout and add dedicated month/day styles
- introduce per-month grids with consistent spacing and responsive tweaks
- wire the worker completion handler to render the tile layout and log the daily summary count

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4f1daeac88330a85536620b529de6