### PR TITLE
feat: populate hero metrics

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,16 @@
 const $ = (s)=>document.querySelector(s);
 const LS = {user:'md_user_name', asst:'md_asst_name', filter:'md_filter_mode', theme:'md_theme'};
 const defaults = {user:'Me', asst:'GPT', filter:'simple', theme:'Echoes'};
+let currentSummary = null;
+
+const nameUserEl = $('#nameU');
+const nameAssistantEl = $('#nameA');
+const overviewMetrics = {
+  user: buildOverviewMetric('#uChars'),
+  assistant: buildOverviewMetric('#aChars')
+};
+const timeMetrics = setupTimeElements();
+const streakMetrics = setupStreakElements();
 
 // —— 读取与应用偏好
 function loadPrefs(){
@@ -15,9 +25,13 @@ function sanitizeName(s){ return (s||'').trim().slice(0,24).replace(/[<>]/g,'');
 
 function applyNames(p){
   $('#title').textContent = `Memory：${p.user}&${p.asst}`;
-  $('#nameU').textContent = p.user; $('#nameA').textContent = p.asst;
+  if(nameUserEl){ nameUserEl.textContent = p.user; }
+  if(nameAssistantEl){ nameAssistantEl.textContent = p.asst; }
   $('#nameU2').textContent = p.user; $('#nameA2').textContent = p.asst;
   $('#userName').value = p.user; $('#assistantName').value = p.asst;
+  if(currentSummary){
+    renderSummaryBasics(currentSummary);
+  }
 }
 function applyFilter(mode){
   document.querySelectorAll('input[name="filter"]').forEach(r=>r.checked=(r.value===mode));
@@ -28,6 +42,46 @@ function applyTheme(theme){
   document.querySelectorAll('.theme').forEach(btn=>{
     btn.setAttribute('aria-pressed', btn.dataset.theme===theme ? 'true':'false');
   });
+}
+
+function buildOverviewMetric(selector){
+  const kpi = $(selector);
+  const metric = kpi ? kpi.closest('.metric') : null;
+  const detail = metric ? metric.querySelector('.sub') : null;
+  return {kpi, metric, detail};
+}
+
+function setupTimeElements(){
+  const earliest = $('#earliest');
+  const hotSlot = $('#hotSlot');
+  let detail = null;
+  if(hotSlot){
+    detail = document.createElement('div');
+    detail.className = 'sub mono muted';
+    hotSlot.insertAdjacentElement('afterend', detail);
+  }
+  return {earliest, hotSlot, detail};
+}
+
+function setupStreakElements(){
+  const nowKpi = $('#streakNow');
+  const maxKpi = $('#streakMax');
+  const nowMetric = nowKpi ? nowKpi.closest('.metric') : null;
+  const maxMetric = maxKpi ? maxKpi.closest('.metric') : null;
+  const nowDetail = createStreakDetail(nowKpi);
+  const maxDetail = createStreakDetail(maxKpi);
+  return {
+    now: {kpi: nowKpi, metric: nowMetric, detail: nowDetail},
+    max: {kpi: maxKpi, metric: maxMetric, detail: maxDetail}
+  };
+}
+
+function createStreakDetail(kpi){
+  if(!kpi){ return null; }
+  const detail = document.createElement('div');
+  detail.className = 'sub mono muted';
+  kpi.insertAdjacentElement('afterend', detail);
+  return detail;
 }
 
 // —— 初始化
@@ -68,7 +122,6 @@ document.querySelectorAll('.theme').forEach(btn=>{
 let fileHandle = null;
 $('#file').onchange = (e)=>{ fileHandle = e.target.files?.[0] || null; $('#status').textContent = fileHandle? `已选择：${fileHandle.name}`:'未加载文件'; };
 const worker = new Worker('./parser.worker.js?v=7', {type:'module'});
-let currentSummary = null;
 
 $('#runPrecheck').onclick = ()=>{
   if(!fileHandle){ $('#status').textContent = '请先选择 JSON 文件'; return; }
@@ -94,11 +147,6 @@ worker.onmessage = (e)=>{
     const {summary = null} = data;
     currentSummary = summary;
     renderSummaryBasics(summary);
-    const hotSlot = summarizeHotSlot(summary?.timeOfDay);
-    $('#hotSlot').textContent = hotSlot || '—';
-    const streaks = calcStreaks(summary?.dayActive);
-    $('#streakNow').textContent = streaks.now || '—';
-    $('#streakMax').textContent = streaks.max || '—';
     let statusText = '解析完成';
     if(summary?.samplingNote === true){
       statusText += '（性能保护：基于抽样）';
@@ -109,13 +157,6 @@ worker.onmessage = (e)=>{
     $('#status').textContent = data.message || '未知错误';
   }
 };
-
-const hourFormatter = new Intl.DateTimeFormat(undefined, {
-  year: 'numeric',
-  month: '2-digit',
-  day: '2-digit',
-  hour: '2-digit'
-});
 
 function clampPct(pct){
   if(!Number.isFinite(pct)){ return '0'; }
@@ -134,39 +175,154 @@ function formatCount(value){
 }
 
 function renderSummaryBasics(summary){
-  if(!summary){
-    $('#uChars').textContent = '0';
-    $('#aChars').textContent = '0';
-    $('#uMsgs').textContent = '0';
-    $('#aMsgs').textContent = '0';
-    $('#earliest').textContent = '—';
+  renderOverviewMetrics(summary);
+  renderTimeMetrics(summary);
+  renderStreakMetrics(summary);
+}
+
+function renderOverviewMetrics(summary){
+  const userData = summary ? {
+    name: getDisplayName(nameUserEl, defaults.user),
+    chars: Number(summary?.totalChars?.user ?? 0),
+    msgs: Number(summary?.totalMsgs?.user ?? 0)
+  } : null;
+  const assistantData = summary ? {
+    name: getDisplayName(nameAssistantEl, defaults.asst),
+    chars: Number(summary?.totalChars?.assistant ?? 0),
+    msgs: Number(summary?.totalMsgs?.assistant ?? 0)
+  } : null;
+  updateOverviewMetric(overviewMetrics.user, userData);
+  updateOverviewMetric(overviewMetrics.assistant, assistantData);
+}
+
+function updateOverviewMetric(target, data){
+  if(!target?.kpi){ return; }
+  if(!data){
+    target.kpi.textContent = '—';
+    if(target.detail){ target.detail.textContent = ''; }
     return;
   }
-
-  const userChars = Number(summary?.totalChars?.user ?? 0);
-  const asstChars = Number(summary?.totalChars?.assistant ?? 0);
-  const userMsgs = Number(summary?.totalMsgs?.user ?? 0);
-  const asstMsgs = Number(summary?.totalMsgs?.assistant ?? 0);
-  $('#uChars').textContent = formatCount(userChars);
-  $('#aChars').textContent = formatCount(asstChars);
-  $('#uMsgs').textContent = formatCount(userMsgs);
-  $('#aMsgs').textContent = formatCount(asstMsgs);
-
-  const ts = summary?.earliestTs;
-  if(ts){
-    const dt = new Date(ts);
-    dt.setMinutes(0, 0, 0);
-    $('#earliest').textContent = hourFormatter.format(dt);
-  } else {
-    $('#earliest').textContent = '—';
+  const charText = formatCount(data.chars);
+  const msgText = formatCount(data.msgs);
+  target.kpi.textContent = `${data.name}：${charText} 字 · ${msgText} 条`;
+  if(target.detail){
+    target.detail.textContent = '';
   }
 }
 
+function renderTimeMetrics(summary){
+  const earliestInfo = summary ? formatEarliestLines(summary?.earliestTs) : null;
+  updateEarliest(earliestInfo);
+  const hotSlotInfo = summary ? summarizeHotSlot(summary?.timeOfDay) : null;
+  updateHotSlot(hotSlotInfo);
+}
+
+function updateEarliest(info){
+  const target = timeMetrics.earliest;
+  if(!target){ return; }
+  if(!info){
+    target.textContent = '—';
+    return;
+  }
+  const {dateLine, timeLine} = info;
+  if(dateLine && timeLine){
+    target.innerHTML = `${dateLine}<br>${timeLine}`;
+  }else if(dateLine){
+    target.textContent = dateLine;
+  }else{
+    target.textContent = '—';
+  }
+}
+
+function updateHotSlot(info){
+  const target = timeMetrics.hotSlot;
+  if(!target){ return; }
+  if(!info){
+    target.textContent = '—';
+    if(timeMetrics.detail){ timeMetrics.detail.textContent = ''; }
+    return;
+  }
+  target.textContent = info.start;
+  if(timeMetrics.detail){
+    const parts = [];
+    if(info.range){ parts.push(info.range); }
+    if(Number.isFinite(info.count) && info.count > 0){
+      parts.push(`${formatCount(info.count)} 条`);
+    }
+    timeMetrics.detail.textContent = parts.length ? `– ${parts.join(' · ')}` : '';
+  }
+}
+
+function renderStreakMetrics(summary){
+  const streaks = summary ? calcStreaks(summary?.dayActive) : {now:null, max:null};
+  const nowRun = streaks?.now || null;
+  const maxRun = streaks?.max || null;
+  const same = streakRunsEqual(nowRun, maxRun);
+  updateStreakMetric(streakMetrics.now, nowRun);
+  if(streakMetrics.max?.metric){
+    streakMetrics.max.metric.style.display = same ? 'none' : '';
+  }
+  if(same){
+    updateStreakMetric(streakMetrics.max, null);
+  }else{
+    updateStreakMetric(streakMetrics.max, maxRun);
+  }
+}
+
+function updateStreakMetric(target, data){
+  if(!target?.kpi){ return; }
+  if(!data){
+    target.kpi.textContent = '—';
+    if(target.detail){ target.detail.textContent = ''; }
+    return;
+  }
+  target.kpi.textContent = `${formatCount(data.length)} 天`;
+  if(target.detail){
+    const start = formatLocalDate(data.start);
+    const end = formatLocalDate(data.end);
+    target.detail.textContent = start && end ? `${start} → ${end}` : '';
+  }
+}
+
+function streakRunsEqual(a, b){
+  if(!a || !b){ return false; }
+  return a.length === b.length && a.start === b.start && a.end === b.end;
+}
+
+function getDisplayName(el, fallback){
+  if(!el){ return fallback; }
+  const text = (el.textContent || '').trim();
+  return text || fallback;
+}
+
+function formatEarliestLines(ts){
+  if(ts === undefined || ts === null){ return null; }
+  const dt = new Date(ts);
+  if(Number.isNaN(dt.getTime())){ return null; }
+  const dateLine = `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`;
+  const normalized = new Date(dt.getTime());
+  normalized.setMinutes(0, 0, 0);
+  const timeLine = `${String(normalized.getHours()).padStart(2, '0')}:${String(normalized.getMinutes()).padStart(2, '0')}`;
+  return {dateLine, timeLine};
+}
+
+function formatLocalDate(dateStr){
+  if(!dateStr){ return ''; }
+  const parts = dateStr.split('-').map(part => Number(part));
+  if(parts.length !== 3 || parts.some(part => !Number.isFinite(part))){
+    return dateStr.replaceAll('/', '-');
+  }
+  const [year, month, day] = parts;
+  const dt = new Date(year, month - 1, day);
+  if(Number.isNaN(dt.getTime())){ return dateStr; }
+  return `${dt.getFullYear()}-${String(dt.getMonth() + 1).padStart(2, '0')}-${String(dt.getDate()).padStart(2, '0')}`;
+}
+
 function summarizeHotSlot(timeOfDay){
-  if(!Array.isArray(timeOfDay) || timeOfDay.length !== 8){ return ''; }
+  if(!Array.isArray(timeOfDay) || timeOfDay.length !== 8){ return null; }
   const values = timeOfDay.map(v => Number(v) || 0);
   const maxVal = Math.max(...values);
-  if(maxVal <= 0){ return ''; }
+  if(maxVal <= 0){ return null; }
   const tzOffsetMinutes = -new Date().getTimezoneOffset();
   const slots = values
     .map((val, idx) => ({ val, idx }))
@@ -174,9 +330,21 @@ function summarizeHotSlot(timeOfDay){
     .map(item => {
       const utcStartMin = item.idx * 180;
       const localStartMin = (utcStartMin + tzOffsetMinutes + 1440) % 1440;
-      return formatSlotRange(localStartMin);
-    });
-  return slots.join('、');
+      return {
+        start: formatHourMinute(localStartMin),
+        range: formatSlotRange(localStartMin),
+        count: Math.round(maxVal)
+      };
+    })
+    .sort((a, b) => a.start.localeCompare(b.start));
+  if(!slots.length){ return null; }
+  const primary = slots[0];
+  const rangeLabel = slots.length > 1 ? slots.map(slot => slot.range).join('、') : primary.range;
+  return {
+    start: primary.start,
+    range: rangeLabel,
+    count: Math.round(maxVal)
+  };
 }
 
 function formatSlotRange(startMinutes){
@@ -201,11 +369,11 @@ function formatHourMinute(totalMinutes){
 
 function calcStreaks(dayActive){
   if(!Array.isArray(dayActive) || !dayActive.length){
-    return {now: '', max: ''};
+    return {now: null, max: null};
   }
   const uniqueSorted = Array.from(new Set(dayActive)).sort();
   if(!uniqueSorted.length){
-    return {now: '', max: ''};
+    return {now: null, max: null};
   }
 
   const runs = [];
@@ -239,16 +407,18 @@ function calcStreaks(dayActive){
   const currentRun = runs[runs.length - 1];
 
   return {
-    now: formatRun(currentRun),
-    max: formatRun(maxRun)
+    now: normalizeRun(currentRun),
+    max: normalizeRun(maxRun)
   };
 }
 
-function formatRun(run){
-  if(!run){ return ''; }
-  const start = run.start.replaceAll('-', '/');
-  const end = run.end.replaceAll('-', '/');
-  return `${start}–${end} · ${run.length}天`;
+function normalizeRun(run){
+  if(!run){ return null; }
+  return {
+    start: run.start,
+    end: run.end,
+    length: run.length
+  };
 }
 
 function renderMonthlyTiles(summary){

--- a/index.html
+++ b/index.html
@@ -15,8 +15,38 @@ body{
 }
 h1{ font-size:28px; font-weight:800; letter-spacing:.2px; margin:0 0 16px }
 .h2{ font-size:18px; font-weight:700; margin:0 0 8px }
-.mono{ font-variant-numeric:tabular-nums }
+.mono{ font-variant-numeric:tabular-nums; font-feature-settings:"tnum" 1, "lnum" 1 }
 .muted{ opacity:.76 }
+.kpi{ font-size:clamp(28px,4vw,32px); font-weight:800; line-height:1.1 }
+.label{ font-size:12px; font-weight:700; letter-spacing:.14em; text-transform:uppercase; opacity:.8 }
+.sub{ font-size:13px; opacity:.7; margin-top:8px }
+.sep{ height:1px; background:currentColor; opacity:.12; margin:8px 0 }
+.hero-grid{
+  display:grid; gap:16px;
+  grid-template-columns:repeat(12,minmax(0,1fr));
+  margin:16px 0 24px;
+}
+.hero{
+  background:var(--card);
+  border-radius:28px;
+  padding:24px;
+  color:var(--text);
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+.hero .label{ margin-bottom:4px }
+.hero .metric-group{ display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); margin-top:4px }
+.hero .metric{ display:flex; flex-direction:column; gap:4px }
+.hero .metric .kpi{ margin-top:4px }
+.hero .sub{ margin-top:0 }
+.hero-time #earliest{ display:block; max-width:14ch; word-break:break-word }
+.hero-streak-grid{ display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(120px,1fr)); }
+.hero-grid .hero{ grid-column:span 12 }
+.hero-time .sep{ margin:12px 0 }
+.hero-time .kpi:last-of-type{ font-size:clamp(22px,3vw,26px) }
+.hero-streak-grid .kpi{ font-size:clamp(24px,4vw,30px) }
+.hero-streak .sub{ margin-top:12px }
 .card{
   background:var(--card); border:none; border-radius:var(--radius);
   padding:16px; margin:12px 0;
@@ -30,6 +60,8 @@ h1{ font-size:28px; font-weight:800; letter-spacing:.2px; margin:0 0 16px }
 .col-4{grid-column:span 4}
 .col-8{grid-column:span 8}
 @media (max-width:860px){ .col-6,.col-4,.col-8{grid-column:span 12} }
+.hero-grid .hero-time,.hero-grid .hero-streak{ grid-column:span 6 }
+@media (max-width:860px){ .hero-grid .hero-time,.hero-grid .hero-streak{ grid-column:span 12 } }
 
 .row{ display:flex; gap:10px; flex-wrap:wrap; align-items:center }
 .input{ padding:8px 10px; border:none; border-radius:12px; background:var(--surface); color:var(--text) }
@@ -107,32 +139,50 @@ body[data-theme="Emotion"]{
     </div>
   </div>
 
-  <!-- 指标分卡片布局 -->
-  <div class="grid">
-    <!-- 概览：总字数/总条数（双向） -->
-    <div class="card col-12">
-      <div class="h2">概览 Overview</div>
-      <div class="row">
-        <div><strong id="nameU">Me</strong>：<span id="uChars" class="mono">0</span> 字・<span id="uMsgs" class="mono">0</span> 条</div>
-        <div><strong id="nameA">GPT</strong>：<span id="aChars" class="mono">0</span> 字・<span id="aMsgs" class="mono">0</span> 条</div>
+  <div class="hero-grid">
+    <div class="hero hero-overview">
+      <div class="label">概览 Overview</div>
+      <div class="metric-group">
+        <div class="metric">
+          <div class="label muted"><span id="nameU">Me</span></div>
+          <div class="kpi mono" id="uChars">0</div>
+          <div class="sub mono">字数・<span id="uMsgs">0</span> 条</div>
+        </div>
+        <div class="metric">
+          <div class="label muted"><span id="nameA">GPT</span></div>
+          <div class="kpi mono" id="aChars">0</div>
+          <div class="sub mono">字数・<span id="aMsgs">0</span> 条</div>
+        </div>
       </div>
     </div>
 
-    <!-- 时间信息：最早时间 + 最常时段 -->
-    <div class="card col-6">
-      <div class="h2">时间 Time</div>
-      <div>最早对话创建时间：<strong id="earliest">—</strong> <span class="muted">（本地时区，精确到小时）</span></div>
-      <div style="margin-top:6px">最常聊天时段：<strong id="hotSlot">—</strong></div>
+    <div class="hero hero-time">
+      <div class="label">时间 Time</div>
+      <div class="kpi mono"><span id="earliest">—</span></div>
+      <div class="sub">本地时区，精确到小时</div>
+      <div class="sep"></div>
+      <div class="label muted">最常聊天时段</div>
+      <div class="kpi mono" id="hotSlot">—</div>
     </div>
 
-    <!-- 连续天数 -->
-    <div class="card col-6">
-      <div class="h2">连续天数 Streak</div>
-      <div>当前：<strong id="streakNow">—</strong></div>
-      <div>最长：<strong id="streakMax">—</strong></div>
-      <div class="muted" style="margin-top:6px">活跃日＝当天 <span id="nameU2">Me</span>/<span id="nameA2">GPT</span> 任一有消息</div>
+    <div class="hero hero-streak">
+      <div class="label">连续天数 Streak</div>
+      <div class="hero-streak-grid">
+        <div class="metric">
+          <div class="label muted">当前</div>
+          <div class="kpi mono" id="streakNow">—</div>
+        </div>
+        <div class="metric">
+          <div class="label muted">最长</div>
+          <div class="kpi mono" id="streakMax">—</div>
+        </div>
+      </div>
+      <div class="sub">活跃日＝当天 <span id="nameU2">Me</span>/<span id="nameA2">GPT</span> 任一有消息</div>
     </div>
+  </div>
 
+  <!-- 指标分卡片布局 -->
+  <div class="grid">
     <!-- 近三月月历字数（纯文本） -->
     <div class="card col-12">
       <div class="h2">最近三月字数分布 Monthly</div>


### PR DESCRIPTION
## Summary
- cache hero card elements and refresh them when display names change
- render overview, time, and streak hero cards with formatted counts, two-line timestamps, and hot slot subtitles
- normalize streak calculations to expose structured data for the UI

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4f7d181b48330b4ef24b4e7b16b7d