### PR TITLE
Refine overview card KPIs and clarify time card

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,8 +6,8 @@ let currentSummary = null;
 const nameUserEl = $('#nameU');
 const nameAssistantEl = $('#nameA');
 const overviewMetrics = {
-  user: buildOverviewMetric('#uChars'),
-  assistant: buildOverviewMetric('#aChars')
+  user: buildOverviewMetric('#uChars', '#uMsgs'),
+  assistant: buildOverviewMetric('#aChars', '#aMsgs')
 };
 const timeMetrics = setupTimeElements();
 const streakMetrics = setupStreakElements();
@@ -44,11 +44,10 @@ function applyTheme(theme){
   });
 }
 
-function buildOverviewMetric(selector){
-  const kpi = $(selector);
-  const metric = kpi ? kpi.closest('.metric') : null;
-  const detail = metric ? metric.querySelector('.sub') : null;
-  return {kpi, metric, detail};
+function buildOverviewMetric(charSelector, msgSelector){
+  const chars = $(charSelector);
+  const msgs = $(msgSelector);
+  return {chars, msgs};
 }
 
 function setupTimeElements(){
@@ -182,12 +181,10 @@ function renderSummaryBasics(summary){
 
 function renderOverviewMetrics(summary){
   const userData = summary ? {
-    name: getDisplayName(nameUserEl, defaults.user),
     chars: Number(summary?.totalChars?.user ?? 0),
     msgs: Number(summary?.totalMsgs?.user ?? 0)
   } : null;
   const assistantData = summary ? {
-    name: getDisplayName(nameAssistantEl, defaults.asst),
     chars: Number(summary?.totalChars?.assistant ?? 0),
     msgs: Number(summary?.totalMsgs?.assistant ?? 0)
   } : null;
@@ -196,18 +193,16 @@ function renderOverviewMetrics(summary){
 }
 
 function updateOverviewMetric(target, data){
-  if(!target?.kpi){ return; }
+  if(!target?.chars || !target?.msgs){ return; }
   if(!data){
-    target.kpi.textContent = '—';
-    if(target.detail){ target.detail.textContent = ''; }
+    target.chars.textContent = '—';
+    target.msgs.textContent = '—';
     return;
   }
   const charText = formatCount(data.chars);
   const msgText = formatCount(data.msgs);
-  target.kpi.textContent = `${data.name}：${charText} 字 · ${msgText} 条`;
-  if(target.detail){
-    target.detail.textContent = '';
-  }
+  target.chars.textContent = `${charText} 字`;
+  target.msgs.textContent = `${msgText} 条`;
 }
 
 function renderTimeMetrics(summary){
@@ -242,14 +237,13 @@ function updateHotSlot(info){
     if(timeMetrics.detail){ timeMetrics.detail.textContent = ''; }
     return;
   }
-  target.textContent = info.start;
+  target.textContent = info.range || info.start || '—';
   if(timeMetrics.detail){
-    const parts = [];
-    if(info.range){ parts.push(info.range); }
     if(Number.isFinite(info.count) && info.count > 0){
-      parts.push(`${formatCount(info.count)} 条`);
+      timeMetrics.detail.textContent = `· ${formatCount(info.count)} 条`;
+    }else{
+      timeMetrics.detail.textContent = '';
     }
-    timeMetrics.detail.textContent = parts.length ? `– ${parts.join(' · ')}` : '';
   }
 }
 
@@ -287,12 +281,6 @@ function updateStreakMetric(target, data){
 function streakRunsEqual(a, b){
   if(!a || !b){ return false; }
   return a.length === b.length && a.start === b.start && a.end === b.end;
-}
-
-function getDisplayName(el, fallback){
-  if(!el){ return fallback; }
-  const text = (el.textContent || '').trim();
-  return text || fallback;
 }
 
 function formatEarliestLines(ts){

--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@ h1{ font-size:28px; font-weight:800; letter-spacing:.2px; margin:0 0 16px }
 .mono{ font-variant-numeric:tabular-nums; font-feature-settings:"tnum" 1, "lnum" 1 }
 .muted{ opacity:.76 }
 .kpi{ font-size:clamp(28px,4vw,32px); font-weight:800; line-height:1.1 }
+.kpi-row{ margin-top:6px }
+.nowrap{ white-space:nowrap; word-break:keep-all }
 .label{ font-size:12px; font-weight:700; letter-spacing:.14em; text-transform:uppercase; opacity:.8 }
 .sub{ font-size:13px; opacity:.7; margin-top:8px }
 .sep{ height:1px; background:currentColor; opacity:.12; margin:8px 0 }
@@ -39,6 +41,8 @@ h1{ font-size:28px; font-weight:800; letter-spacing:.2px; margin:0 0 16px }
 .hero .metric-group{ display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); margin-top:4px }
 .hero .metric{ display:flex; flex-direction:column; gap:4px }
 .hero .metric .kpi{ margin-top:4px }
+.hero .metric .kpi-row{ margin-top:6px }
+.hero .metric .kpi-row:first-of-type{ margin-top:4px }
 .hero .sub{ margin-top:0 }
 .hero-time #earliest{ display:block; max-width:14ch; word-break:break-word }
 .hero-streak-grid{ display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(120px,1fr)); }
@@ -145,13 +149,13 @@ body[data-theme="Emotion"]{
       <div class="metric-group">
         <div class="metric">
           <div class="label muted"><span id="nameU">Me</span></div>
-          <div class="kpi mono" id="uChars">0</div>
-          <div class="sub mono">字数・<span id="uMsgs">0</span> 条</div>
+          <div class="kpi mono nowrap kpi-row" id="uChars">0 字</div>
+          <div class="kpi mono nowrap kpi-row" id="uMsgs">0 条</div>
         </div>
         <div class="metric">
           <div class="label muted"><span id="nameA">GPT</span></div>
-          <div class="kpi mono" id="aChars">0</div>
-          <div class="sub mono">字数・<span id="aMsgs">0</span> 条</div>
+          <div class="kpi mono nowrap kpi-row" id="aChars">0 字</div>
+          <div class="kpi mono nowrap kpi-row" id="aMsgs">0 条</div>
         </div>
       </div>
     </div>
@@ -159,7 +163,7 @@ body[data-theme="Emotion"]{
     <div class="hero hero-time">
       <div class="label">时间 Time</div>
       <div class="kpi mono"><span id="earliest">—</span></div>
-      <div class="sub">本地时区，精确到小时</div>
+      <div class="sub">本地时区，精确到小时 · 此处为最早消息时间（来自导出文件的最小时间戳）</div>
       <div class="sep"></div>
       <div class="label muted">最常聊天时段</div>
       <div class="kpi mono" id="hotSlot">—</div>


### PR DESCRIPTION
## Summary
- stack each participant's overview KPIs into dedicated character and message rows without duplicate labels
- add spacing and no-wrap helpers to keep large figures on single lines in the overview card
- update KPI rendering logic to populate the new character and message fields
- clarify the time card subtext and show the full hot-slot range with the optional message count note

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4fe882d94833085d36d0ba454fdb3