### PR TITLE
Remove filter controls from control bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,16 +120,12 @@ body[data-theme="Emotion"]{
       <label>对方显示名（assistant）<input id="assistantName" class="input" placeholder="GPT" type="text"></label>
       <button id="saveNames">保存并应用</button>
       <button id="resetNames" class="ghost">重置</button>
-      <span class="badge">仅近三月统计</span>
-    </div>
-    <div class="row" style="margin-top:8px">
-      <label><input type="radio" name="filter" value="simple" checked> 简单过滤</label>
-      <label><input type="radio" name="filter" value="deep"> 深度过滤</label>
-      <span style="flex:1"></span>
       <span class="muted">主题：</span>
       <button class="theme ghost" data-theme="Echoes" aria-pressed="true">Echoes</button>
       <button class="theme ghost" data-theme="Logic" aria-pressed="false">Logic</button>
       <button class="theme ghost" data-theme="Emotion" aria-pressed="false">Emotion</button>
+      <span style="flex:1"></span>
+      <span class="badge">仅近三月统计</span>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- remove the simple/deep filter controls from the top card
- place the theme selection buttons alongside the name controls while keeping layout spacing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d60cf0d6b48330ae814d5e30d81694