### PR TITLE
Update highlights section title and layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -106,8 +106,7 @@ function setupStreakElements(){
 
 function setupHighlightElements(){
   return {
-    topDays: $('#hlTopDays'),
-    ratios: $('#hlRatios')
+    topDays: $('#hlTopDays')
   };
 }
 

--- a/index.html
+++ b/index.html
@@ -227,11 +227,10 @@ body[data-theme="Emotion"]{
   </div>
 
   <div class="card" id="highlights">
-    <div class="h2">Highlights (recent 3 months)</div>
-    <div id="hlRatios"></div>
+    <div class="h2">高光（最近三个月）</div>
     <div id="hlTopDays" class="hl-list"></div>
   </div>
 
-  <script type="module" src="./app.js?v=35"></script>
+  <script type="module" src="./app.js?v=36"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rename the Highlights card title to the requested Chinese text
- remove the unused ratios container and related JavaScript hook
- bump the app.js cache-busting query to v=36

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63c2ebe948330b5b0cfef911b7acf