### PR TITLE
Rework highlights tiles layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -106,8 +106,7 @@ function setupStreakElements(){
 
 function setupHighlightElements(){
   return {
-    topDays: $('#hlTopDays'),
-    ratios: $('#hlRatios')
+    topDays: $('#hlTopDays')
   };
 }
 
@@ -549,8 +548,10 @@ function renderHighlights(summary){
   const topDaysEl = highlights?.topDays;
   if(!topDaysEl){ return; }
 
-  const emptyText = 'No activity in the recent 3-month window.';
+  const emptyText = '最近三个月没有可显示的活跃日。';
   const monthDailyChars = summary?.monthDailyChars;
+  topDaysEl.innerHTML = '';
+
   if(!monthDailyChars || Object.keys(monthDailyChars).length === 0){
     topDaysEl.textContent = emptyText;
     return;
@@ -573,30 +574,28 @@ function renderHighlights(summary){
   });
 
   const topTen = entries.slice(0, 10);
-  if(!topTen.length){
+  if(topTen.length === 0){
     topDaysEl.textContent = emptyText;
     return;
   }
 
+  const fmt = new Intl.NumberFormat();
   const fragment = document.createDocumentFragment();
 
-  topTen.forEach(item => {
-    const row = document.createElement('div');
-    row.className = 'hl-item';
-
-    const dateSpan = document.createElement('span');
-    dateSpan.className = 'hl-date';
-    dateSpan.textContent = item.date;
-    row.appendChild(dateSpan);
-
-    const valueSpan = document.createElement('span');
-    valueSpan.className = 'hl-val';
-    valueSpan.textContent = numberFormatter.format(Math.trunc(item.chars));
-    row.appendChild(valueSpan);
-
-    fragment.appendChild(row);
+  topTen.forEach((item, idx) => {
+    const tile = document.createElement('div');
+    let extraClass = '';
+    if(idx === 0){
+      extraClass = ' hl-top1';
+    } else if(idx === 1){
+      extraClass = ' hl-top2';
+    } else if(idx === 2){
+      extraClass = ' hl-top3';
+    }
+    tile.className = `hl-tile${extraClass}`;
+    tile.innerHTML = `<div class="hl-date">${item.date}</div><div class="hl-chars">${fmt.format(item.chars)}</div>`;
+    fragment.appendChild(tile);
   });
 
-  topDaysEl.innerHTML = '';
   topDaysEl.appendChild(fragment);
 }

--- a/index.html
+++ b/index.html
@@ -131,10 +131,30 @@ body[data-theme="Emotion"]{
   margin-top:10px;
 }
 
-.hl-list{ display:flex; flex-direction:column; gap:6px; }
-.hl-item{ display:flex; justify-content:space-between; }
-.hl-date{ font-weight:700; }
-.hl-val{ font-variant-numeric: tabular-nums; }
+/* Highlights tile grid */
+.hl-grid{
+  display:grid;
+  grid-template-columns: repeat(5, minmax(0,1fr)); /* desktop */
+  gap:10px;
+}
+@media (max-width:1024px){ .hl-grid{ grid-template-columns: repeat(4,1fr); } }
+@media (max-width:860px){  .hl-grid{ grid-template-columns: repeat(3,1fr); } }
+@media (max-width:560px){  .hl-grid{ grid-template-columns: repeat(2,1fr); } }
+
+.hl-tile{
+  background: var(--surface);
+  border-radius: var(--radius);
+  min-height: 70px;
+  padding: 8px 10px;
+  display:flex; flex-direction:column; justify-content:space-between; align-items:flex-start;
+  font-variant-numeric: tabular-nums;
+}
+.hl-date{ font-weight:700; opacity:.95; }
+.hl-chars{ font-size:12px; opacity:.95; }
+
+/* Optional: stronger accent for Top 3 */
+.hl-top1{ background: var(--accent); color: var(--accent-contrast); }
+.hl-top2, .hl-top3{ box-shadow: 0 0 0 9999px rgba(0,0,0,0) inset; }
 
 </style>
 
@@ -227,11 +247,10 @@ body[data-theme="Emotion"]{
   </div>
 
   <div class="card" id="highlights">
-    <div class="h2">Highlights (recent 3 months)</div>
-    <div id="hlRatios"></div>
-    <div id="hlTopDays" class="hl-list"></div>
+    <div class="h2">高光（最近三个月）</div>
+    <div id="hlTopDays" class="hl-grid"></div>
   </div>
 
-  <script type="module" src="./app.js?v=35"></script>
+  <script type="module" src="./app.js?v=37"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the highlights list with a responsive tile grid sorted by character count
- add styling hooks for the top tiles and localized empty state messaging
- bump the app.js cache-busting parameter to v=37 to load the refreshed layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d63c2ebe948330b5b0cfef911b7acf