### PR TITLE
Compact highlights tile grid

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ function spawnWorker(){
   if(state.worker){
     state.worker.terminate();
   }
-  state.worker = new Worker('./parser.worker.js?v=35', { type: 'module' });
+  state.worker = new Worker('./parser.worker.js?v=38', { type: 'module' });
   state.worker.onmessage = onWorkerMessage;
 }
 
@@ -106,8 +106,7 @@ function setupStreakElements(){
 
 function setupHighlightElements(){
   return {
-    topDays: $('#hlTopDays'),
-    ratios: $('#hlRatios')
+    topDays: $('#hlTopDays')
   };
 }
 
@@ -549,54 +548,46 @@ function renderHighlights(summary){
   const topDaysEl = highlights?.topDays;
   if(!topDaysEl){ return; }
 
-  const emptyText = 'No activity in the recent 3-month window.';
+  const emptyText = '最近三个月没有可显示的活跃日。';
   const monthDailyChars = summary?.monthDailyChars;
+  topDaysEl.innerHTML = '';
+
   if(!monthDailyChars || Object.keys(monthDailyChars).length === 0){
     topDaysEl.textContent = emptyText;
     return;
   }
 
-  const entries = Object.entries(monthDailyChars)
-    .map(([date, value]) => ({ date, chars: Number(value) }))
+  const items = Object.entries(monthDailyChars)
+    .map(([date, chars]) => ({ date, chars: Number(chars) }))
     .filter(item => Number.isFinite(item.chars));
 
-  if(entries.length === 0){
+  if(items.length === 0){
     topDaysEl.textContent = emptyText;
     return;
   }
 
-  entries.sort((a, b) => {
+  items.sort((a, b) => {
     if(b.chars !== a.chars){
       return b.chars - a.chars;
     }
     return a.date.localeCompare(b.date);
   });
 
-  const topTen = entries.slice(0, 10);
-  if(!topTen.length){
+  const top10 = items.slice(0, 10);
+  if(top10.length === 0){
     topDaysEl.textContent = emptyText;
     return;
   }
 
+  const fmt = new Intl.NumberFormat();
   const fragment = document.createDocumentFragment();
 
-  topTen.forEach(item => {
-    const row = document.createElement('div');
-    row.className = 'hl-item';
-
-    const dateSpan = document.createElement('span');
-    dateSpan.className = 'hl-date';
-    dateSpan.textContent = item.date;
-    row.appendChild(dateSpan);
-
-    const valueSpan = document.createElement('span');
-    valueSpan.className = 'hl-val';
-    valueSpan.textContent = numberFormatter.format(Math.trunc(item.chars));
-    row.appendChild(valueSpan);
-
-    fragment.appendChild(row);
+  top10.forEach((item, idx) => {
+    const tile = document.createElement('div');
+    tile.className = `hl-tile${idx === 0 ? ' hl-top1' : ''}`;
+    tile.innerHTML = `<div class="hl-date">${item.date}</div><div class="hl-chars">${fmt.format(item.chars)}</div>`;
+    fragment.appendChild(tile);
   });
 
-  topDaysEl.innerHTML = '';
   topDaysEl.appendChild(fragment);
 }

--- a/index.html
+++ b/index.html
@@ -131,10 +131,35 @@ body[data-theme="Emotion"]{
   margin-top:10px;
 }
 
-.hl-list{ display:flex; flex-direction:column; gap:6px; }
-.hl-item{ display:flex; justify-content:space-between; }
-.hl-date{ font-weight:700; }
-.hl-val{ font-variant-numeric: tabular-nums; }
+/* Highlights: 5×2 compact square tiles */
+.hl-grid{
+  display:grid;
+  grid-template-columns: repeat(5, minmax(0,1fr));
+  gap:10px;                /* fixed spacing between tiles */
+  margin-top:8px;
+}
+.hl-tile{
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 6px 8px;
+  aspect-ratio: 1 / 1;     /* square */
+  display:flex;
+  flex-direction:column;
+  justify-content:space-between;
+  align-items:flex-start;
+  font-variant-numeric: tabular-nums;
+  min-height:0;            /* prevent unexpected growth */
+}
+.hl-date{ font-weight:700; opacity:.95; line-height:1.2; }
+.hl-chars{ font-size:12px; opacity:.95; }
+
+/* Optional: highlight Top 1 */
+.hl-top1{ background: var(--accent); color: var(--accent-contrast); }
+
+/* (Optional responsive fallback for very narrow screens)
+@media (max-width:640px){ .hl-grid{ grid-template-columns: repeat(3,1fr); } }
+@media (max-width:480px){ .hl-grid{ grid-template-columns: repeat(2,1fr); } }
+*/
 
 </style>
 
@@ -227,11 +252,10 @@ body[data-theme="Emotion"]{
   </div>
 
   <div class="card" id="highlights">
-    <div class="h2">Highlights (recent 3 months)</div>
-    <div id="hlRatios"></div>
-    <div id="hlTopDays" class="hl-list"></div>
+    <div class="h2">高光（最近三个月）</div>
+    <div id="hlTopDays" class="hl-grid"></div>
   </div>
 
-  <script type="module" src="./app.js?v=35"></script>
+  <script type="module" src="./app.js?v=38"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle the highlights section with a fixed 5×2 grid of square tiles and accent for the top day
- update highlight rendering to sort daily character counts and apply the compact layout classes
- bump the app and worker cache-busting versions to v=38

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d63c2ebe948330b5b0cfef911b7acf